### PR TITLE
Add an ipynb file intended for use in jupyter notebook

### DIFF
--- a/fluxvis.ipynb
+++ b/fluxvis.ipynb
@@ -1,0 +1,58 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "touched-diana",
+   "metadata": {},
+   "source": [
+    "# Welcome to the Flux Visualization notebook!\n",
+    "\n",
+    "To use this notebook, select \"run all\". After a delay, the \"Upload\" button will appear. Click it and then select the file to upload. After the upload is complete, the visualization will be shown below. You can save an image by right clicking.\n",
+    "\n",
+    "If you need to change the visualization settings, add or modify arguments to the `go()` call (e.g., to set the `tracks=`), then hit ctrl-enter to re-evaluate the cell, and upload again. The initial pre-sets are for Apple II 5.25\" floppies stored in `.a2r` format, showing only full tracks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "synthetic-freedom",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install fluxvis 'ipywidgets>=7.4,<8'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "quiet-arcade",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fluxvis.notebook import go\n",
+    "go()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/fluxvis.ipynb
+++ b/fluxvis.ipynb
@@ -21,7 +21,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install fluxvis 'ipywidgets>=7.4,<8'"
+    "!pip install 'fluxvis[notebook]'"
    ]
   },
   {

--- a/fluxvis.ipynb
+++ b/fluxvis.ipynb
@@ -9,7 +9,9 @@
     "\n",
     "To use this notebook, select \"run all\". After a delay, the \"Upload\" button will appear. Click it and then select the file to upload. After the upload is complete, the visualization will be shown below. You can save an image by right clicking.\n",
     "\n",
-    "If you need to change the visualization settings, add or modify arguments to the `go()` call (e.g., to set the `tracks=`), then hit ctrl-enter to re-evaluate the cell, and upload again. The initial pre-sets are for Apple II 5.25\" floppies stored in `.a2r` format, showing only full tracks."
+    "If you need to change the visualization settings, add or modify arguments to the `go()` call (e.g., to set the `tracks=`), then hit ctrl-enter to re-evaluate the cell, and upload again. The initial pre-sets are for Apple II 5.25\" floppies stored in `.a2r` format, showing only full tracks.\n",
+    "\n",
+    "The full source for fluxvis is [on github](https://github.com/adafruit/fluxvis) and can be installed locally [from pypi](https://pypi.org/project/fluxvis/) via `pip install fluxvis`."
    ]
   },
   {

--- a/fluxvis.ipynb.license
+++ b/fluxvis.ipynb.license
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2022 Jeff Epler for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT

--- a/fluxvis/greaseweazle/image/adf.py
+++ b/fluxvis/greaseweazle/image/adf.py
@@ -6,7 +6,7 @@
 # See the file COPYING for more details, or visit <http://unlicense.org>.
 
 from . import error
-import .codec.amiga.amigados as amigados
+from . import codec.amiga.amigados as amigados
 from .img import IMG
 from .image import Image
 

--- a/fluxvis/notebook.py
+++ b/fluxvis/notebook.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2022 Jeff Epler for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""Helper function for use in Jupyter Notebook"""
+
+import io
+import os
+import tempfile
+import shutil
+from ipywidgets import FileUpload
+from IPython.display import display
+import matplotlib.pyplot as plt
+from . import open_flux, process
+
+
+def go(
+    side=0,
+    tracks=35,
+    start=0,
+    stride=4,
+    linear=False,
+    slices=800,
+    stacks=3,
+    location=None,
+    diameter=108,
+    resolution=900,
+    oversample=2,
+):  # pylint: disable=invalid-name,too-many-arguments
+    """Main helper function for operation in a notebook"""
+    uploader = FileUpload(accept=".a2r,.scp", multiple=False)
+
+    display(uploader)
+
+    def on_upload_change(_):
+        try:
+            for meta, content in zip(uploader.metadata, uploader.data):
+                print(f"processing {meta['name']} with content of {len(content)} bytes")
+                process_one_flux(meta["name"], content)
+        finally:
+            uploader.metadata.clear()
+            uploader.data.clear()
+            uploader._counter = 0  # pylint: disable=protected-access
+
+    def process_one_flux(filename, content):
+        with io.BytesIO(content) as b, tempfile.NamedTemporaryFile(
+            suffix=os.path.splitext(filename)[1]
+        ) as t:
+            shutil.copyfileobj(b, t)
+            flux = open_flux(t.name)
+        density = process(
+            flux,
+            side=side,
+            tracks=tracks,
+            start=start,
+            stride=stride,
+            linear=linear,
+            slices=slices,
+            stacks=stacks,
+            location=location,
+            diameter=diameter,
+            resolution=resolution,
+            oversample=oversample,
+        )
+
+        fig, axis = plt.subplots()
+        fig.set_dpi(96)
+        fig.set_size_inches(density.shape[0] / 96, density.shape[1] / 96)
+        fig.set_frameon(False)
+        fig.set_tight_layout(True)
+        plt.axis("off")
+        axis.imshow(density)
+        plt.show()
+
+    uploader.observe(on_upload_change, names="_counter")

--- a/fluxvis/notebook.py
+++ b/fluxvis/notebook.py
@@ -47,6 +47,7 @@ def go(
             suffix=os.path.splitext(filename)[1]
         ) as t:
             shutil.copyfileobj(b, t)
+            t.flush()
             flux = open_flux(t.name)
         density = process(
             flux,

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,3 +36,6 @@ install_requires =
 [options.entry_points]
 console_scripts =
     fluxvis = fluxvis.__main__:main
+
+[options.extras_require]
+    notebook = ipywidgets>=7.4,<8


### PR DESCRIPTION
This can allow a user to run fluxvis inside e.g., google colab without installing any software on their local computer.

To test, go to https://colab.research.google.com/github/jepler/fluxvis/blob/notebook/fluxvis.ipynb (which loads the notebook from this PR branch) and change the pip line to
```
!pip install 'git+https://github.com/jepler/fluxvis@notebook#egg=fluxvis[notebook]'
```
(which installs fluxvis from this PR branch including extra dependencies when running in a notebook), then run all cells.

It could be better, because:
 * it doesn't support .csv location files
 * changing arguments is a pain possibly even worse than using the command line
Both could be the subject of future improvements (though the multi-file-handling may be tricky!)